### PR TITLE
Simplify gitignore and also include demoshop folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
-mkmf.log
-.vagrant/
-saltstack
-saltstack/
-pillar
-pillar/
-spryker
-spryker/
-
+/mkmf.log
+/.vagrant
+/saltstack
+/pillar
+/spryker
+/.idea
+/demoshop


### PR DESCRIPTION
Currenty demoshop and .idea (phpstorm) folders are not included and show up in uncommited list which is bad.
Also there is no need to declare them all twice.

//cc @marek-obuchowicz and Marcel