### PR TITLE
Suggested improvements

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,9 +1,23 @@
-# Helpers
-def colorize(text, color_code); "#{color_code}#{text}\033[0m"; end
-def red(text); colorize(text, "\033[31m"); end
-def yellow(text); colorize(text, "\033[33m"); end
-def green(text); colorize(text, "\033[32m"); end
-def bold(text); colorize(text, "\033[1;97m"); end
+require './helpers'
+require 'mkmf'
+
+unless find_executable 'git'
+  abort red "ERROR: git executable was found."
+end
+
+# Cleanup mkmf log
+File.delete('mkmf.log') if File.exists?('mkmf.log')
+
+required_plugins = ['vagrant-vbguest', 'vagrant-hostmanager']
+plugins_to_install = required_plugins.select { |plugin| !Vagrant.has_plugin? plugin }
+unless plugins_to_install.empty?
+  puts "Installing plugins: #{plugins_to_install.join(', ')}"
+  if system "vagrant plugin install #{plugins_to_install.join(' ')}"
+    exec "vagrant #{ARGV.join(' ')}"
+  else
+    abort red "Installation of one or more plugins has failed. Aborting."
+  end
+end
 
 ###
 ### BEGINNING OF CONFIGURATION
@@ -25,7 +39,6 @@ if File.exists? VM_SETTINGS_FILE
     File.delete(VM_SETTINGS_FILE)
   end
 else
-
   # Project settings
   VM_PROJECT = ENV['VM_PROJECT'] || 'demoshop'                         # Name of the project
   SPRYKER_REPOSITORY = ENV['SPRYKER_REPOSITORY'] || "git@github.com:spryker/#{VM_PROJECT}.git"
@@ -44,9 +57,10 @@ else
     "VM_MEMORY =          '#{VM_MEMORY}'\n" +
     "VM_CPUS =            '#{VM_CPUS}'\n" +
     "VM_NAME =            '#{VM_NAME}'\n" +
+    "SPRYKER_BRANCH =     '#{SPRYKER_BRANCH}'\n" +
     "SPRYKER_REPOSITORY = '#{SPRYKER_REPOSITORY}'\n"
 
-  if not ARGV.include? 'destroy'
+  unless ARGV.include? 'destroy'
     puts yellow "New VM settings will be used:"
     puts config
     puts bold "Press return to save it in file .vm, Ctrl+C to abort"
@@ -78,53 +92,19 @@ end
 ### END OF CONFIGURATION
 ###
 
-# Check whether we are running UNIX or Windows-based machine
-if Vagrant::Util::Platform.windows?
-  HOSTS_PATH = 'c:\WINDOWS\system32\drivers\etc\hosts'
-  IS_WINDOWS = true
-  IS_UNIX = false
-  IS_LINUX = false
-  IS_OSX = false
-  SYNCED_FOLDER_OPTIONS = { type: 'virtualbox' }
-else
-  HOSTS_PATH = '/etc/hosts'
-  IS_WINDOWS = false
-  IS_UNIX = true
-  if (/darwin/ =~ Vagrant::Util::Platform.platform)
-    IS_LINUX = false
-    IS_OSX = true
-    SYNCED_FOLDER_OPTIONS = { type: 'nfs' }
-  else
-    IS_LINUX = true
-    IS_OSX = false
-    SYNCED_FOLDER_OPTIONS = { type: 'nfs', mount_options: ['nolock'] }
-  end
-end
-
 # Verify if salt/pillar directories are present
-require 'mkmf'
 has_fresh_repos = false
 
-if not Dir.exists?(SALT_DIRECTORY)
-  if find_executable 'git'
-    puts bold "Cloning SaltStack git repository..."
-    system "git clone #{SALT_REPOSITORY} --branch #{SALT_BRANCH} #{SALT_DIRECTORY}"
-    has_fresh_repos = true
-  else
-    raise "ERROR: Required #{SALT_DIRECTORY} could not be found and no git executable was found to solve this problem." +
-    "\n\n\033[0m"
-  end
+unless Dir.exists?(SALT_DIRECTORY)
+  puts bold "Cloning SaltStack git repository..."
+  system "git clone #{SALT_REPOSITORY} --branch #{SALT_BRANCH} #{SALT_DIRECTORY}"
+  has_fresh_repos = true
 end
 
-if not Dir.exists?(PILLAR_DIRECTORY)
-  if find_executable 'git'
-    puts bold "Cloning Pillar git repository..."
-    system "git clone #{PILLAR_REPOSITORY} --branch #{PILLAR_BRANCH} #{PILLAR_DIRECTORY}"
-    has_fresh_repos = true
-  else
-    raise "ERROR: Required #{PILLAR_DIRECTORY} could not be found and no git executable was found to solve this problem." +
-    "\n\n\033[0m"
-  end
+unless Dir.exists?(PILLAR_DIRECTORY)
+  puts bold "Cloning Pillar git repository..."
+  system "git clone #{PILLAR_REPOSITORY} --branch #{PILLAR_BRANCH} #{PILLAR_DIRECTORY}"
+  has_fresh_repos = true
 end
 
 if has_fresh_repos
@@ -134,21 +114,13 @@ end
 
 # Clone Spryker (if repository is given)
 if defined?(SPRYKER_REPOSITORY)
-  if not Dir.exists?(SPRYKER_DIRECTORY) and not SPRYKER_REPOSITORY.empty?
+  if Dir[SPRYKER_DIRECTORY + "/*"].empty? and not SPRYKER_REPOSITORY.empty?
     puts bold "Cloning Spryker git repository..."
-    if find_executable 'git'
-      system "git clone #{SPRYKER_REPOSITORY} --branch #{SPRYKER_BRANCH} #{SPRYKER_DIRECTORY}"
-    else
-      raise "ERROR: Required #{SPRYKER_DIRECTORY} could not be found and no git executable was found to solve this problem." +
-      "\n\n\033[0m"
-    end
+    system "git clone #{SPRYKER_REPOSITORY} --branch #{SPRYKER_BRANCH} #{SPRYKER_DIRECTORY}"
   end
 else
   puts yellow "Spryker repository is not defined in Vagrantfile - not cloning it..."
 end
-
-# Cleanup mkmf log
-File.delete('mkmf.log') if File.exists?('mkmf.log') and not IS_WINDOWS
 
 Vagrant.configure(2) do |config|
   # Base box for initial setup. Latest Debian (stable) is recommended.
@@ -164,55 +136,43 @@ Vagrant.configure(2) do |config|
   # The VirtualBox IP-address for the browser
   config.vm.network :private_network, ip: VM_IP
 
-  # Port forwarding for services running on VM, does not work on Windows
-  if not IS_WINDOWS
-    config.vm.network "forwarded_port", guest: 1080,  host: 1080,  auto_correct: true   # Mailcatcher
-    config.vm.network "forwarded_port", guest: 3306,  host: 3306,  auto_correct: true   # MySQL
-    config.vm.network "forwarded_port", guest: 5432,  host: 5432,  auto_correct: true   # PostgreSQL
-    config.vm.network "forwarded_port", guest: 10007, host: 10007, auto_correct: true   # Jenkins (development)
-  end
+  # Port forwarding for services running on VM
+  config.vm.network "forwarded_port", guest: 1080,  host: 1080,  auto_correct: true   # Mailcatcher
+  config.vm.network "forwarded_port", guest: 3306,  host: 3306,  auto_correct: true   # MySQL
+  config.vm.network "forwarded_port", guest: 5432,  host: 5432,  auto_correct: true   # PostgreSQL
+  config.vm.network "forwarded_port", guest: 10007, host: 10007, auto_correct: true   # Jenkins (development)
 
   # install required, but missing dependencies into the base box
   config.vm.provision "shell", inline: "sudo apt-get install -qqy pkg-config python2.7-dev"
 
   # SaltStack masterless setup
   if Dir.exists?(PILLAR_DIRECTORY) && Dir.exists?(SALT_DIRECTORY)
-    config.vm.synced_folder SALT_DIRECTORY,   "/srv/salt/",   SYNCED_FOLDER_OPTIONS
-    config.vm.synced_folder PILLAR_DIRECTORY, "/srv/pillar/", SYNCED_FOLDER_OPTIONS
+    config.vm.synced_folder SALT_DIRECTORY,   "/srv/salt/",   { type: 'virtualbox', type: 'nfs', mount_options: ['nolock'] }
+    config.vm.synced_folder PILLAR_DIRECTORY, "/srv/pillar/", { type: 'virtualbox', type: 'nfs', mount_options: ['nolock'] }
     config.vm.provision :salt do |salt|
       salt.minion_config = "salt_minion"
       salt.run_highstate = true
       salt.bootstrap_options = "-F -P -c /tmp"
     end
   else
-    raise "ERROR: Salt (#{SALT_DIRECTORY}) or Pillar (#{PILLAR_DIRECTORY}) directory not found.\n\n\033[0m"
+    abort yellow "ERROR: Salt (#{SALT_DIRECTORY}) or Pillar (#{PILLAR_DIRECTORY}) directory not found."
   end
 
   # add hosts to /etc/hosts
-  if Vagrant.has_plugin? 'vagrant-hostmanager'
-    puts bold "Configuring vagrant-hostmanager (#{HOSTS.count} hostnames)..."
-    config.hostmanager.enabled = true
-    config.hostmanager.manage_host = true
-    config.hostmanager.manage_guest = true
-    config.hostmanager.ignore_private_ip = false
-    config.hostmanager.include_offline = true
-    config.hostmanager.aliases = HOSTS
-    config.vm.provision :hostmanager
-    puts "Using vagrant-hostmanager to set hostnames: " + HOSTS.join(', ')
-  else
-    hosts_line = VM_IP + " " + HOSTS.join(' ')
-    if not File.open(HOSTS_PATH).each_line.any? { |line| line.chomp == hosts_line }
-      puts bold "Please add the following entries to your #{HOSTS_PATH} file: \n\033[0m"
-      puts hosts_line
-    end
-  end
+  puts bold "Configuring vagrant-hostmanager (#{HOSTS.count} hostnames)..."
+  config.hostmanager.enabled = true
+  config.hostmanager.manage_host = true
+  config.hostmanager.manage_guest = true
+  config.hostmanager.ignore_private_ip = false
+  config.hostmanager.include_offline = true
+  config.hostmanager.aliases = HOSTS
+  config.vm.provision :hostmanager
+  puts "Using vagrant-hostmanager to set hostnames: " + HOSTS.join(', ')
 
   # Share the application code with VM
-  config.vm.synced_folder SPRYKER_DIRECTORY, "/data/shop/development/current", SYNCED_FOLDER_OPTIONS
-  if IS_UNIX
-    config.nfs.map_uid = Process.uid
-    config.nfs.map_gid = Process.gid
-  end
+  config.vm.synced_folder SPRYKER_DIRECTORY, "/data/shop/development/current", { type: 'virtualbox', type: 'nfs', mount_options: ['nolock'] }
+  config.nfs.map_uid = Process.uid
+  config.nfs.map_gid = Process.gid
 
   # Configure VirtualBox VM resources (CPU and memory)
   config.vm.provider :virtualbox do |vb|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,8 @@ required_plugins = ['vagrant-vbguest', 'vagrant-hostmanager']
 plugins_to_install = required_plugins.select { |plugin| !Vagrant.has_plugin? plugin }
 unless plugins_to_install.empty?
   puts "Installing plugins: #{plugins_to_install.join(', ')}"
+  # exec will replace the current thread (which makes it like restarting vagrant)
+  # while system run the command `vagrant plugin install` on the current thread if there's any `plugins_to_install`
   if system "vagrant plugin install #{plugins_to_install.join(' ')}"
     exec "vagrant #{ARGV.join(' ')}"
   else
@@ -147,8 +149,8 @@ Vagrant.configure(2) do |config|
 
   # SaltStack masterless setup
   if Dir.exists?(PILLAR_DIRECTORY) && Dir.exists?(SALT_DIRECTORY)
-    config.vm.synced_folder SALT_DIRECTORY,   "/srv/salt/",   { type: 'virtualbox', type: 'nfs', mount_options: ['nolock'] }
-    config.vm.synced_folder PILLAR_DIRECTORY, "/srv/pillar/", { type: 'virtualbox', type: 'nfs', mount_options: ['nolock'] }
+    config.vm.synced_folder SALT_DIRECTORY,   "/srv/salt/",   { type: 'nfs', mount_options: ['nolock'] }
+    config.vm.synced_folder PILLAR_DIRECTORY, "/srv/pillar/", { type: 'nfs', mount_options: ['nolock'] }
     config.vm.provision :salt do |salt|
       salt.minion_config = "salt_minion"
       salt.run_highstate = true
@@ -170,7 +172,7 @@ Vagrant.configure(2) do |config|
   puts "Using vagrant-hostmanager to set hostnames: " + HOSTS.join(', ')
 
   # Share the application code with VM
-  config.vm.synced_folder SPRYKER_DIRECTORY, "/data/shop/development/current", { type: 'virtualbox', type: 'nfs', mount_options: ['nolock'] }
+  config.vm.synced_folder SPRYKER_DIRECTORY, "/data/shop/development/current", { type: 'nfs', mount_options: ['nolock'] }
   config.nfs.map_uid = Process.uid
   config.nfs.map_gid = Process.gid
 

--- a/Vagrantfile-quick
+++ b/Vagrantfile-quick
@@ -5,16 +5,26 @@
 # For building the "quick start" box file, the default Vagrantfile is used,
 # like on dev vms created with full saltstack provisioning.
 
-# On buildhost, following vagrant plugins must be installed:
-#  - vagrant-hostmanager
-#  - vagrant-vbguest
+require './helpers'
+require 'mkmf'
 
-# Helpers
-def colorize(text, color_code); "#{color_code}#{text}\033[0m"; end
-def red(text); colorize(text, "\033[31m"); end
-def yellow(text); colorize(text, "\033[33m"); end
-def green(text); colorize(text, "\033[32m"); end
-def bold(text); colorize(text, "\033[1;97m"); end
+unless find_executable 'git'
+  abort red "ERROR: git executable was found."
+end
+
+# Cleanup mkmf log
+File.delete('mkmf.log') if File.exists?('mkmf.log')
+
+required_plugins = ['vagrant-vbguest', 'vagrant-hostmanager']
+plugins_to_install = required_plugins.select { |plugin| !Vagrant.has_plugin? plugin }
+unless plugins_to_install.empty?
+  puts "Installing plugins: #{plugins_to_install.join(', ')}"
+  if system "vagrant plugin install #{plugins_to_install.join(' ')}"
+    exec "vagrant #{ARGV.join(' ')}"
+  else
+    abort red "Installation of one or more plugins has failed. Aborting."
+  end
+end
 
 ###
 ### BEGINNING OF CONFIGURATION
@@ -34,7 +44,6 @@ if File.exists? VM_SETTINGS_FILE
     File.delete(VM_SETTINGS_FILE)
   end
 else
-
   # Project settings
   VM_PROJECT = ENV['VM_PROJECT'] || 'demoshop'                         # Name of the project
   SPRYKER_REPOSITORY = ENV['SPRYKER_REPOSITORY'] || "git@github.com:spryker/#{VM_PROJECT}.git"
@@ -53,9 +62,10 @@ else
     "VM_MEMORY =          '#{VM_MEMORY}'\n" +
     "VM_CPUS =            '#{VM_CPUS}'\n" +
     "VM_NAME =            '#{VM_NAME}'\n" +
+    "SPRYKER_BRANCH =     '#{SPRYKER_BRANCH}'\n" +
     "SPRYKER_REPOSITORY = '#{SPRYKER_REPOSITORY}'\n"
 
-  if not ARGV.include? 'destroy'
+  unless ARGV.include? 'destroy'
     puts yellow "New VM settings will be used:"
     puts config
     puts bold "Press return to save it in file .vm, Ctrl+C to abort"
@@ -81,55 +91,15 @@ end
 ### END OF CONFIGURATION
 ###
 
-# Helpers
-def colorize(text, color_code); "#{color_code}#{text}\033[0m"; end
-def red(text); colorize(text, "\033[31m"); end
-def yellow(text); colorize(text, "\033[33m"); end
-def green(text); colorize(text, "\033[32m"); end
-def bold(text); colorize(text, "\033[1;97m"); end
-
-# Check whether we are running UNIX or Windows-based machine
-if Vagrant::Util::Platform.windows?
-  HOSTS_PATH = 'c:\WINDOWS\system32\drivers\etc\hosts'
-  IS_WINDOWS = true
-  IS_UNIX = false
-  IS_LINUX = false
-  IS_OSX = false
-  SYNCED_FOLDER_OPTIONS = { type: 'virtualbox' }
-else
-  HOSTS_PATH = '/etc/hosts'
-  IS_WINDOWS = false
-  IS_UNIX = true
-  if (/darwin/ =~ Vagrant::Util::Platform.platform)
-    IS_LINUX = false
-    IS_OSX = true
-    SYNCED_FOLDER_OPTIONS = { type: 'nfs' }
-  else
-    IS_LINUX = true
-    IS_OSX = false
-    SYNCED_FOLDER_OPTIONS = { type: 'nfs', mount_options: ['nolock'] }
-  end
-end
-
 # Clone Spryker (if repository is given)
-require 'mkmf'
-
 if defined?(SPRYKER_REPOSITORY)
-  if not Dir.exists?(SPRYKER_DIRECTORY) and not SPRYKER_REPOSITORY.empty?
+  if Dir[SPRYKER_DIRECTORY + "/*"].empty? and not SPRYKER_REPOSITORY.empty?
     puts bold "Cloning Spryker git repository..."
-    if find_executable 'git'
-      system "git clone #{SPRYKER_REPOSITORY} --branch #{SPRYKER_BRANCH} #{SPRYKER_DIRECTORY}"
-    else
-      raise "ERROR: Required #{SPRYKER_DIRECTORY} could not be found and no git executable was found to solve this problem." +
-      "\n\n\033[0m"
-    end
+    system "git clone #{SPRYKER_REPOSITORY} --branch #{SPRYKER_BRANCH} #{SPRYKER_DIRECTORY}"
   end
 else
   puts yellow "Spryker repository is not defined in Vagrantfile or variable SPRYKER_REPOSITORY - not cloning it..."
 end
-
-# Cleanup mkmf log
-File.delete('mkmf.log') if File.exists?('mkmf.log') and not IS_WINDOWS
 
 Vagrant.configure(2) do |config|
   # Base box for initial setup. Latest Debian (stable) is recommended.
@@ -145,38 +115,26 @@ Vagrant.configure(2) do |config|
   # The VirtualBox IP-address for the browser
   config.vm.network :private_network, ip: VM_IP
 
-  # Port forwarding for services running on VM, does not work on Windows
-  if not IS_WINDOWS
-    config.vm.network "forwarded_port", guest: 1080,  host: 1080,  auto_correct: true   # Mailcatcher
-    config.vm.network "forwarded_port", guest: 3306,  host: 3306,  auto_correct: true   # MySQL
-    config.vm.network "forwarded_port", guest: 5432,  host: 5432,  auto_correct: true   # PostgreSQL
-    config.vm.network "forwarded_port", guest: 10007, host: 10007, auto_correct: true   # Jenkins (development)
-  end
+  # Port forwarding for services running on VM
+  config.vm.network "forwarded_port", guest: 1080,  host: 1080,  auto_correct: true   # Mailcatcher
+  config.vm.network "forwarded_port", guest: 3306,  host: 3306,  auto_correct: true   # MySQL
+  config.vm.network "forwarded_port", guest: 5432,  host: 5432,  auto_correct: true   # PostgreSQL
+  config.vm.network "forwarded_port", guest: 10007, host: 10007, auto_correct: true   # Jenkins (development)
 
   # add hosts to /etc/hosts
-  if Vagrant.has_plugin? 'vagrant-hostmanager'
-    config.hostmanager.enabled = true
-    config.hostmanager.manage_host = true
-    config.hostmanager.manage_guest = true
-    config.hostmanager.ignore_private_ip = false
-    config.hostmanager.include_offline = true
-    config.hostmanager.aliases = HOSTS
-    config.vm.provision :hostmanager
-    puts "Using vagrant-hostmanager to set hostnames: " + HOSTS.join(', ')
-  else
-    hosts_line = VM_IP + " " + HOSTS.join(' ')
-    if not File.open(HOSTS_PATH).each_line.any? { |line| line.chomp == hosts_line }
-      puts bold "Please add the following entries to your #{HOSTS_PATH} file: \n\033[0m"
-      puts hosts_line
-    end
-  end
+  config.hostmanager.enabled = true
+  config.hostmanager.manage_host = true
+  config.hostmanager.manage_guest = true
+  config.hostmanager.ignore_private_ip = false
+  config.hostmanager.include_offline = true
+  config.hostmanager.aliases = HOSTS
+  config.vm.provision :hostmanager
+  puts "Using vagrant-hostmanager to set hostnames: " + HOSTS.join(', ')
 
   # Share the application code with VM
-  config.vm.synced_folder SPRYKER_DIRECTORY, "/data/shop/development/current", SYNCED_FOLDER_OPTIONS
-  if IS_UNIX
-    config.nfs.map_uid = Process.uid
-    config.nfs.map_gid = Process.gid
-  end
+  config.vm.synced_folder SPRYKER_DIRECTORY, "/data/shop/development/current", { type: 'virtualbox', type: 'nfs', mount_options: ['nolock'] }
+  config.nfs.map_uid = Process.uid
+  config.nfs.map_gid = Process.gid
 
   # Configure VirtualBox VM resources (CPU and memory)
   config.vm.provider :virtualbox do |vb|

--- a/helpers.rb
+++ b/helpers.rb
@@ -1,0 +1,6 @@
+# Helpers
+def colorize(text, color_code); "#{color_code}#{text}\033[0m"; end
+def red(text); colorize(text, "\033[31m"); end
+def yellow(text); colorize(text, "\033[33m"); end
+def green(text); colorize(text, "\033[32m"); end
+def bold(text); colorize(text, "\033[1;97m"); end


### PR DESCRIPTION
- Extract the helper functions to a separate file.
- Vagrant can handle different platforms (usually by ignoring problems/differences).
  - `forwarded_port` works on windows and if there's any collision `auto_correct: true` will instruct vagrant  to solve it.
  - vagrant simply [ignores `nfs` instruction on windows](https://www.vagrantup.com/docs/synced-folders/nfs.html), so you can just have it without a condition on the platform.
  - Determining the platform (for specific configurations) isn't really needed because the box is pre-provisioned (you only need to consider the build machine platform).
- `vagrant-hostmanager` is installed and used exclusively now, no need to check if it's installed anymore.
- Check for `git` executable before starting, fail if not found.
- `SPRYKER_BRANCH` wasn't persisted into the configuration `.vm` file.