### PR TITLE
xdebug.sh - a script to toggle xdebug

### DIFF
--- a/xdebug.sh
+++ b/xdebug.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+PHP_VERSION=`php -v`
+PHP_ETC_DIR=/etc/php7/
+PHP_VERSION_NUMBER=7
+
+if [[ $PHP_VERSION =~ "PHP 5" ]] ; then
+    PHP_ETC_DIR=/etc/php5/
+    PHP_VERSION_NUMBER=5
+fi
+
+XDEBUG_INI=${PHP_ETC_DIR}mods-available/xdebug.ini
+PHP_CLI_DIR=${PHP_ETC_DIR}cli/conf.d/
+PHP_FPM_DIR=${PHP_ETC_DIR}fpm/conf.d/
+
+echo "Detected PHP version: ${PHP_VERSION_NUMBER}.x";
+
+function restartFPM {
+	sudo /etc/init.d/php5-fpm restart
+}
+
+function xdebugOn {
+	if [ ! -f "${PHP_CLI_DIR}30-xdebug.ini" ]; then
+		echo "Enabling CLI Xdebug"
+		sudo ln -s $XDEBUG_INI "${PHP_CLI_DIR}30-xdebug.ini"
+	else
+		echo " - CLI Xdebug already enabled"
+	fi
+
+    if [ ! -f "${PHP_FPM_DIR}30-xdebug.ini" ]; then
+        echo "Enabling FPM Xdebug"
+		sudo ln -s $XDEBUG_INI "${PHP_FPM_DIR}30-xdebug.ini"
+		restartFPM
+    else
+        echo " - FPM Xdebug already enabled"
+    fi 
+}
+
+function xdebugOff {
+    if [ -f "${PHP_CLI_DIR}30-xdebug.ini" ]; then
+        echo "Disabling CLI Xdebug"
+        sudo rm "${PHP_CLI_DIR}30-xdebug.ini"
+    else
+        echo " - CLI Xdebug is not enabled"
+    fi  
+
+    if [ -f "${PHP_FPM_DIR}30-xdebug.ini" ]; then
+        echo "Disabling FPM Xdebug"
+        sudo rm "${PHP_FPM_DIR}30-xdebug.ini"
+		restartFPM
+    else
+        echo " - FPM Xdebug is not enabled"
+    fi  
+}
+
+function reportStatus {
+    if [ -f "${PHP_CLI_DIR}30-xdebug.ini" ]; then
+        echo "CLI Xdebug is enabled"
+	else
+		echo "CLI Xdebug is disabled"	
+    fi
+
+    if [ -f "${PHP_FPM_DIR}30-xdebug.ini" ]; then
+        echo "FPM Xdebug is enabled"
+    else
+        echo "FPM Xdebug is disabled"   
+    fi
+}
+
+case $1 in
+    --on) 
+		xdebugOn
+	;;
+    --off) 
+		xdebugOff
+	;;
+
+    *) 
+		reportStatus
+		echo "Use --on or --off"
+	;;
+esac;

--- a/xdebug.sh
+++ b/xdebug.sh
@@ -3,9 +3,11 @@
 PHP_VERSION=`php -v`
 PHP_ETC_DIR=/etc/php/7.0/
 PHP_VERSION_NUMBER=7
+PHP_FPM=/etc/init.d/php7.0-fpm
 
 if [[ $PHP_VERSION =~ "PHP 5" ]] ; then
     PHP_ETC_DIR=/etc/php5/
+    PHP_FPM=/etc/init.d/php5-fpm
     PHP_VERSION_NUMBER=5
 fi
 
@@ -16,7 +18,7 @@ PHP_FPM_DIR=${PHP_ETC_DIR}fpm/conf.d/
 echo "Detected PHP version: ${PHP_VERSION_NUMBER}.x";
 
 function restartFPM {
-	sudo /etc/init.d/php5-fpm restart
+	sudo $PHP_FPM restart
 }
 
 function xdebugOn {

--- a/xdebug.sh
+++ b/xdebug.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 PHP_VERSION=`php -v`
-PHP_ETC_DIR=/etc/php7/
+PHP_ETC_DIR=/etc/php/7.0/
 PHP_VERSION_NUMBER=7
 
 if [[ $PHP_VERSION =~ "PHP 5" ]] ; then


### PR DESCRIPTION
A script to disable / enable xdebug.
It should be executed inside vagrant.
Automatically detects PHP version.
Automatically detects if xdebug is already enabled / disabled.
Restarts php-fpm.

```
./xdebug.sh

Detected PHP version: 5.x
CLI Xdebug is enabled
FPM Xdebug is enabled
Use --on or --off
```

```
./xdebug.sh --on

Detected PHP version: 5.x
 - CLI Xdebug already enabled
 - FPM Xdebug already enabled
```

```
./xdebug.sh --off

Detected PHP version: 5.x
Disabling CLI Xdebug
Disabling FPM Xdebug
[ ok ] Restarting php5-fpm (via systemctl): php5-fpm.service.
```


```
./xdebug.sh --on 

Detected PHP version: 5.x
Enabling CLI Xdebug
Enabling FPM Xdebug
[ ok ] Restarting php5-fpm (via systemctl): php5-fpm.service.
```
