### PR TITLE
[BUGFIX] Add missing linebreak to have VM_MEMORY defined

### DIFF
--- a/Vagrantfile-quick
+++ b/Vagrantfile-quick
@@ -43,7 +43,8 @@ else
 
   # Settings for the Virtualbox VM
   VM_IP_PREFIX = ENV['VM_IP_PREFIX'] || '10.10.0.'                         # Prefix for IP address of DEV VM
-  VM_IP        = ENV['VM_IP']        || VM_IP_PREFIX + unique_byte         # IP Address of the DEV VM, must be unique  VM_MEMORY  = ENV['VM_MEMORY']  || '3200'                             # Amount of memory for DEV VM, in MB
+  VM_IP        = ENV['VM_IP']        || VM_IP_PREFIX + unique_byte         # IP Address of the DEV VM, must be unique
+  VM_MEMORY    = ENV['VM_MEMORY']    || '3200'                             # Amount of memory for DEV VM, in MB
   VM_CPUS      = ENV['VM_CPUS']      || '4'                                # Amount of CPU cores for DEV VM
   VM_NAME      = ENV['VM_NAME']      || "Spryker Dev VM (#{VM_PROJECT})"   # Visible name in VirtualBox
   VM_SKIP_SF   = ENV['VM_SKIP_SF']   || '0'                                # Don't mount shared folders


### PR DESCRIPTION
The `VM_MEMORY` constant was considered a comment since it was missing a line break to appear on a dedicated line