### PR TITLE
Revert "Allow projects configuration for stores setup"

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,7 +39,6 @@ else
   VM_CPUS      = ENV['VM_CPUS']      || '4'                                # Amount of CPU cores for DEV VM
   VM_NAME      = ENV['VM_NAME']      || "Spryker Dev VM (#{VM_PROJECT})"   # Visible name in VirtualBox
   VM_SKIP_SF   = ENV['VM_SKIP_SF']   || '0'                                # Don't mount shared folders
-  VM_STORES    = (ENV['VM_STORES'] || 'de,at,us').split(',')               # Hostnames to be managed
 
   config=
     "VM_PROJECT =         '#{VM_PROJECT}'\n" +
@@ -47,7 +46,6 @@ else
     "VM_MEMORY =          '#{VM_MEMORY}'\n" +
     "VM_CPUS =            '#{VM_CPUS}'\n" +
     "VM_NAME =            '#{VM_NAME}'\n" +
-    "VM_STORES =          '#{VM_STORES.join(',')}'\n" +
     "VM_SKIP_SF =         '#{VM_SKIP_SF}'\n" +
     "SPRYKER_BRANCH =     '#{SPRYKER_BRANCH}'\n" +
     "SPRYKER_REPOSITORY = '#{SPRYKER_REPOSITORY}'\n"
@@ -72,10 +70,12 @@ SALT_BRANCH        = ENV['SALT_BRANCH']        || "master"
 PILLAR_REPOSITORY  = ENV['PILLAR_REPOSITORY']  || "git@github.com:spryker/pillar.git"
 PILLAR_BRANCH      = ENV['PILLAR_BRANCH']      || "master"
 
+# Hostnames to be managed
+STORES = ['de', 'at', 'us']
 HOSTS = []
 ['', '-test'].each do |host_suffix|
   domain = VM_PROJECT + '.local'
-  VM_STORES.each do |store|
+  STORES.each do |store|
     HOSTS.push [ "www#{host_suffix}.#{store}.#{domain}", "zed#{host_suffix}.#{store}.#{domain}",]
   end
   HOSTS.push [ "static#{host_suffix}.#{domain}" ]

--- a/Vagrantfile-quick
+++ b/Vagrantfile-quick
@@ -48,7 +48,6 @@ else
   VM_CPUS      = ENV['VM_CPUS']      || '4'                                # Amount of CPU cores for DEV VM
   VM_NAME      = ENV['VM_NAME']      || "Spryker Dev VM (#{VM_PROJECT})"   # Visible name in VirtualBox
   VM_SKIP_SF   = ENV['VM_SKIP_SF']   || '0'                                # Don't mount shared folders
-  VM_STORES    = (ENV['VM_STORES'] || 'de,at,us').split(',')               # Hostnames to be managed
 
   config=
     "VM_PROJECT =         '#{VM_PROJECT}'\n" +
@@ -57,7 +56,6 @@ else
     "VM_CPUS =            '#{VM_CPUS}'\n" +
     "VM_NAME =            '#{VM_NAME}'\n" +
     "VM_DOMAIN =          '#{VM_DOMAIN}'\n" +
-    "VM_STORES =          '#{VM_STORES.join(',')}'\n" +
     "VM_SKIP_SF =         '#{VM_SKIP_SF}'\n" +
     "SPRYKER_BRANCH =     '#{SPRYKER_BRANCH}'\n" +
     "SPRYKER_REPOSITORY = '#{SPRYKER_REPOSITORY}'\n"
@@ -76,10 +74,12 @@ end
 # Backward compatibility for .vm file
 VM_SKIP_SF = '0' if not defined? VM_SKIP_SF
 
+# Hostnames to be managed
+STORES = ['de', 'at', 'us']
 HOSTS = []
 ['', '-test'].each do |host_suffix|
   domain = VM_DOMAIN + '.local'
-  VM_STORES.each do |store|
+  STORES.each do |store|
     HOSTS.push [ "www#{host_suffix}.#{store}.#{domain}", "zed#{host_suffix}.#{store}.#{domain}",]
   end
   HOSTS.push [ "static#{host_suffix}.#{domain}" ]


### PR DESCRIPTION
Reverts spryker/devvm#45

```
+ vagrant up
New VM settings will be used:
VM_PROJECT =         'demoshop'
VM_IP =              '10.10.0.190'
VM_MEMORY =          '8192'
VM_CPUS =            '2'
VM_NAME =            'Spryker Dev VM 1.0.0 (build-139)'
VM_STORES =          'de,at,us'
VM_SKIP_SF =         '0'
SPRYKER_BRANCH =     'master'
SPRYKER_REPOSITORY = ''
Press return to save it in file .vm, Ctrl+C to abort
If the settings above are fine, they will be persisted on disk.
To change any setting, interrupt now and set environmental variable.
Spryker repository is not defined or empty in Vagrantfile - can't clone the repository...
Configuring vagrant-hostmanager (8 hostnames)...
Using vagrant-hostmanager to set hostnames: www.de.demoshop.local, zed.de.demoshop.local, www.at.demoshop.local, zed.at.demoshop.local, www.us.demoshop.local, zed.us.demoshop.local, static.demoshop.local, www-test.de.demoshop.local, zed-test.de.demoshop.local, www-test.at.demoshop.local, zed-test.at.demoshop.local, www-test.us.demoshop.local, zed-test.us.demoshop.local, static-test.demoshop.local
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'debian91_8'...
Progress: 40%Progress: 60%Progress: 70%Progress: 80%Progress: 90%==> default: Matching MAC address for NAT networking...
==> default: Setting the name of the VM: Spryker Dev VM 1.0.0 (build-139)
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
    default: Adapter 2: hostonly
==> default: Forwarding ports...
    default: 1080 (guest) => 1080 (host) (adapter 1)
    default: 3306 (guest) => 3306 (host) (adapter 1)
    default: 5432 (guest) => 5432 (host) (adapter 1)
    default: 5601 (guest) => 5601 (host) (adapter 1)
    default: 10007 (guest) => 10007 (host) (adapter 1)
    default: 22 (guest) => 2222 (host) (adapter 1)
==> default: Running 'pre-boot' VM customizations...
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2222
    default: SSH username: vagrant
    default: SSH auth method: private key
    default:
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default:
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if it's present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Machine booted and ready!
[default] GuestAdditions 5.1.26 running --- OK.
==> default: Checking for guest additions in VM...
==> default: Setting hostname...
==> default: Configuring and enabling network interfaces...
==> default: Exporting NFS shared folders...
==> default: Preparing to edit /etc/exports. Administrator privileges will be required...
==> default: Mounting NFS shared folders...
==> default: Mounting shared folders...
    default: /vagrant => <https://jenkins.korekontrol.net/job/spryker-vm-core/ws/>
==> default: [vagrant-hostmanager:guests] Updating hosts file on active guest virtual machines...
==> default: [vagrant-hostmanager:host] Updating hosts file on your workstation (password may be required)...

We trust you have received the usual lecture from the local System
Administrator. It usually boils down to these three things:

    #1) Respect the privacy of others.
    #2) Think before you type.
    #3) With great power comes great responsibility.

sudo: no tty present and no askpass program specified
==> default: Running provisioner: shell...
    default: Running: inline script
==> default: Running provisioner: salt...
Copying salt minion config to vm.
Checking if salt-minion is installed
salt-minion was not found.
Checking if salt-call is installed
salt-call was not found.
Bootstrapping Salt... (this may take a while)
Salt successfully configured and installed!
run_overstate set to false. Not running state.overstate.
Calling state.highstate... (this may take a while)
orchestrate is nil. Not running state.orchestrate.
==> default: Running provisioner: hostmanager...

We trust you have received the usual lecture from the local System
Administrator. It usually boils down to these three things:

    #1) Respect the privacy of others.
    #2) Think before you type.
    #3) With great power comes great responsibility.

sudo: no tty present and no askpass program specified
+ vagrant vbguest
Loading VM settings file: .vm
There was an error loading a Vagrantfile. The file being loaded
and the error message are shown below. This is usually caused by
a syntax error.

Path: <https://jenkins.korekontrol.net/job/spryker-vm-core/ws/Vagrantfile>
Line number: 78
Message: NoMethodError: undefined method `each' for "de,at,us":String
+ vagrant destroy --force
Loading VM settings file: .vm
Deleting VM settings file: .vm
There was an error loading a Vagrantfile. The file being loaded
and the error message are shown below. This is usually caused by
a syntax error.

Path: <https://jenkins.korekontrol.net/job/spryker-vm-core/ws/Vagrantfile>
Line number: 78
Message: NoMethodError: undefined method `each' for "de,at,us":String
Build step 'Execute shell' marked build as failure
```