### PR TITLE
PS-2618 Use staging/live env configuration by default (production)

### DIFF
--- a/saltstack/dev/development/files/home/vagrant/oh-my-zsh/custom/plugins/spryker/spryker.plugin.zsh
+++ b/saltstack/dev/development/files/home/vagrant/oh-my-zsh/custom/plugins/spryker/spryker.plugin.zsh
@@ -12,7 +12,7 @@ debug-console () {
 }
 
 install () {
-    /data/shop/development/current/vendor/bin/install $*
+    APPLICATION_ENV=development /data/shop/development/current/vendor/bin/install $*
 }
 
 # XDebug


### PR DESCRIPTION
Ticket: https://spryker.atlassian.net/browse/PS-2618

Base PR: https://github.com/spryker/install/pull/17

- Inside devvm run of `install` or `install DE` (not vendor/bin/install) will be run with APPLICATION_ENV=development set