### PR TITLE
Disable audio

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -246,6 +246,7 @@ Vagrant.configure(2) do |config|
       "--cpus", VM_CPUS,
       "--nictype1", "virtio",
       "--nictype2", "virtio",
+      "--audio", "none",
     ])
     if IS_WINDOWS
       # Enable creation of symlinks


### PR DESCRIPTION
I get strange noises when starting the machine and since audio is not used and can be disabled without restrictions, i don't see any reasons why it shouldn't be disabled.

macOS Mojave 10.14.3
Vagrant 2.2.4
VirtualBox 6.0.4